### PR TITLE
7326: Rename envs (ENV CHANGES)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,5 +1,6 @@
 DATASTORE=redis
 BEARER_TOKEN=***
 REDIS_HOST=redis
-API_KEY=***
-API_BASE=https://borndigitalchatgptinternaltest.openai.azure.com
+OPEN_AI_API_KEY=***
+OPEN_AI_API_BASE=https://borndigitalchatgptinternaltest.openai.azure.com
+AI_EMBEDDING_MODEL_NAME="text-embedding-ada-002"

--- a/services/openai.py
+++ b/services/openai.py
@@ -4,7 +4,10 @@ import os
 
 from tenacity import retry, wait_random_exponential, stop_after_attempt
 
-openai.api_key = os.environ.get('API_KEY')
+openai.api_key = os.environ.get('OPEN_AI_API_KEY') or os.environ.get('API_KEY')
+openai.api_base = os.environ.get('OPEN_AI_API_BASE', 'https://api.openai.com')
+
+EMBEDDING_MODEL = os.environ.get('AI_EMBEDDING_MODEL_NAME', "text-embedding-ada-002")
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(3))
 def get_embeddings(texts: List[str]) -> List[List[float]]:
@@ -21,7 +24,7 @@ def get_embeddings(texts: List[str]) -> List[List[float]]:
         Exception: If the OpenAI API call fails.
     """
     # Call the OpenAI API to get the embeddings
-    response = openai.Embedding.create(input=texts, model="text-embedding-ada-002")
+    response = openai.Embedding.create(input=texts, model=EMBEDDING_MODEL)
     # Extract the embedding data from the response
     data = response["data"]  # type: ignore
     # Return the embeddings as a list of lists of floats


### PR DESCRIPTION
https://dev.azure.com/borndigitalai/Born%20Digital/_sprints/backlog/Born%20Digital%20All%20projects/Born%20Digital/Sprint%2052%20-%20Voicebot%20-%20Chatbot?workitem=7326

Env variable names were changed to comply with how they are named in other apps. One careful redeploy is all it takes.

```
API_KEY -> OPEN_AI_API_KEY=
OPEN_AI_API_BASE=
AI_EMBEDDING_MODEL_NAME=text-embedding-ada-002
```